### PR TITLE
Added styles for code blocks and inline code

### DIFF
--- a/web_design.css
+++ b/web_design.css
@@ -1964,6 +1964,21 @@ a.author.moderator:after { content: ""; }
 	line-height: 1.35em;
 }
 
+.md code
+{
+	background: #eee;
+	border-bottom: 1px solid #5B92FA;
+	padding: 0 0.4em;
+	border-radius: 2px;
+}
+
+.md pre code {
+	display: block;
+	padding: 1em;
+	border-left: 4px solid #5B92FA;
+	border-bottom: 0;
+}
+
 hr
 {
 	border-width: 1px;


### PR DESCRIPTION
I placed the style next to the comment styles for ease of locating it in the future, but I intentionally left off the '.comments-page .comment'  so that it would also apply to self post body text on both the comments page and the main page (when the self post is expanded).
