### PR TITLE
Change z-index of .drop-choices.lightdrop

### DIFF
--- a/web_design.css
+++ b/web_design.css
@@ -125,7 +125,7 @@ Added
 }
 
 .drop-choices.lightdrop {
-  z-index: 99;
+  z-index: 1000;
 }
 
 .linkflair-highlight .linkflairlabel {


### PR DESCRIPTION
This is to fix the issue of the comment text field being positioned above the drop menu, preventing it from being accessible as reported [here](https://www.reddit.com/r/web_design/comments/6n651p/while_were_on_the_subject_of_web_design/).