### PR TITLE
Fixed #searchexpando label padding

### DIFF
--- a/web_design.css
+++ b/web_design.css
@@ -258,3 +258,8 @@ body .btn, body button {
 .submit-page .roundfield .title {
     text-transform: none;
 }
+
+/* Reduce padding on Search label - "Limit my search to..." */
+#search #searchexpando label {
+    padding: 0 10px;
+}


### PR DESCRIPTION
The label had a large padding-top and bottom, causing it to push the label to the bottom of the dropdown. Fixes #66